### PR TITLE
virtio-net: Add missing flag define to struct

### DIFF
--- a/content.tex
+++ b/content.tex
@@ -3305,6 +3305,7 @@ itself is preceded by a header:
 \begin{lstlisting}
 struct virtio_net_hdr {
 #define VIRTIO_NET_HDR_F_NEEDS_CSUM    1
+#define VIRTIO_NET_HDR_F_DATA_VALID    2
         u8 flags;
 #define VIRTIO_NET_HDR_GSO_NONE        0
 #define VIRTIO_NET_HDR_GSO_TCPV4       1


### PR DESCRIPTION
The flag VIRTIO_NET_HDR_F_DATA_VALID is aleady  mentioned in the virtio-net
spec however it is not defined in the struct. This flag is already defined
and used in virtio-net device in Qemu as well as some of it's drivers.

Signed-off-by: Sameeh Jubran <sjubran@redhat.com>