### PR TITLE
Clarifying section "2.6.12 virtqueue Operation"

### DIFF
--- a/split-ring.tex
+++ b/split-ring.tex
@@ -569,9 +569,9 @@ the device.
 \begin{note} As an
 example, the simplest virtio network device has two virtqueues: the
 transmit virtqueue and the receive virtqueue. The driver adds
-outgoing (device-readable) packets to the transmit virtqueue, and then
-frees them after they are used. Similarly, incoming (device-writable)
-buffers are added to the receive virtqueue, and processed after
+outgoing packets as device-readable buffers to the transmit virtqueue, and then
+frees them after they are used. Similarly, device-writable buffers for incoming 
+packets are added to the receive virtqueue, and processed after
 they are used.
 \end{note}
 


### PR DESCRIPTION
We'd like to propose clarifying the usage of packets and buffers in section "2.6.12 virtqueue operation" in the note part.

This is the current writing:

"Note: As an example, the simplest virtio network device has two virtqueues: the transmit virtqueue and the receive virtqueue. The driver adds outgoing (device-readable) packets to the transmit virtqueue, and then frees them after they are used. Similarly, incoming (device-writable) buffers are added to the receive virtqueue, and processed after they are used."

And this is the proposed writing:

"Note: As an example, the simplest virtio network device has two virtqueues: the transmit virtqueue and the receive virtqueue. The driver adds outgoing packets as device-readable buffers to the transmit virtqueue, and then frees them after they are used. Similarly, device-writable buffers for incoming packets are added to the receive virtqueue, and processed after they are used."

# Thanks for proposing a change to the Virtual I/O Device (VIRTIO) specification!
The VIRTIO TC is not yet accepting pull requests at this time as they are not
integrated with our voting system.

Instead, please
- [] Propose the spec change (preferably as a patch) on the [mailing list](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=virtio#feedback).
- [] Open an [issue](https://github.com/oasis-tcs/virtio-spec/issues),
     including the link to the proposal in the [mailing list archives](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=virtio#feedback).

The TC will vote and apply the change.
